### PR TITLE
fix: CommunityList API 호출 구조 개선 (#22)

### DIFF
--- a/src/api/community.ts
+++ b/src/api/community.ts
@@ -1,0 +1,27 @@
+import type {
+  CommunityPostsParams,
+  CommunityPostsResponse,
+} from '../pages/CommunityList/lib/types';
+
+const API_BASE = '/api/community';
+
+export async function fetchCommunityPosts(
+  params: CommunityPostsParams,
+): Promise<CommunityPostsResponse> {
+  const searchParams = new URLSearchParams({
+    category: params.category,
+    searchType: params.searchType,
+    searchQuery: params.searchQuery,
+    sort: params.sort,
+    page: String(params.page),
+    limit: String(params.limit),
+  });
+
+  const response = await fetch(`${API_BASE}/posts?${searchParams}`);
+
+  if (!response.ok) {
+    throw new Error('게시글 목록을 불러오는데 실패했습니다.');
+  }
+
+  return response.json();
+}

--- a/src/pages/CommunityList/lib/communityQueries.ts
+++ b/src/pages/CommunityList/lib/communityQueries.ts
@@ -2,26 +2,8 @@
 // Figma-states: communityList
 
 import { queryOptions, useQuery } from '@tanstack/react-query';
-import type { CommunityPostsParams, CommunityPostsResponse } from './types';
-
-async function fetchCommunityPosts(
-  params: CommunityPostsParams,
-): Promise<CommunityPostsResponse> {
-  const searchParams = new URLSearchParams({
-    category: params.category,
-    searchType: params.searchType,
-    searchQuery: params.searchQuery,
-    sort: params.sort,
-    page: String(params.page),
-    limit: String(params.limit),
-  });
-
-  const response = await fetch(`/api/community/posts?${searchParams}`);
-  if (!response.ok) {
-    throw new Error('게시글 목록을 불러오는데 실패했습니다.');
-  }
-  return response.json();
-}
+import { fetchCommunityPosts } from '../../../api/community';
+import type { CommunityPostsParams } from './types';
 
 export const communityQueries = {
   all: () => ['community'] as const,


### PR DESCRIPTION
Closes #22

## 변경사항
- `src/api/community.ts` 생성: fetch 함수를 별도 API 모듈로 분리
- `communityQueries.ts`에서 인라인 fetch 함수 제거, `src/api/community.ts`에서 import
- TanStack Query Factory Pattern 준수
- MSW 핸들러가 `/api/community/posts` 엔드포인트를 정상 인터셉트 확인

## 변경 파일
- `src/api/community.ts` (신규) - API fetch 함수
- `src/pages/CommunityList/lib/communityQueries.ts` (수정) - 외부 API 함수 import

## 검증
- TypeScript 타입체크 통과
- ESLint 린트 통과
- 디자인 토큰 검증 통과
- MSW를 통한 데이터 로딩 정상 확인 (스크린샷 검증)

## 테스트 계획
- [ ] 커뮤니티 목록 페이지 접속 시 게시글 목록 정상 렌더링
- [ ] 카테고리 필터링 정상 동작
- [ ] 검색 기능 정상 동작
- [ ] 정렬 기능 정상 동작
- [ ] 페이지네이션 정상 동작