### PR TITLE
feat: CommunityDetail 페이지 실제 기능 개발 (#32)

### DIFF
--- a/src/api/communityDetail.ts
+++ b/src/api/communityDetail.ts
@@ -1,0 +1,90 @@
+import type {
+  PostDetail,
+  CommentsResponse,
+  CreateCommentRequest,
+  UpdateCommentRequest,
+  DeletePostResponse,
+  LikeResponse,
+} from '../pages/CommunityDetail/lib/types';
+import { authApi, publicApi } from './instance';
+
+const API_BASE = '/api/v1/posts';
+
+/** 게시글 상세 조회 */
+export async function fetchPostDetail(postId: number): Promise<PostDetail> {
+  const { data } = await publicApi.get<PostDetail>(`${API_BASE}/${postId}`);
+  return data;
+}
+
+/** 게시글 삭제 */
+export async function deletePost(postId: number): Promise<DeletePostResponse> {
+  const { data } = await authApi.delete<DeletePostResponse>(
+    `${API_BASE}/${postId}`,
+  );
+  return data;
+}
+
+/** 댓글 목록 조회 */
+export async function fetchComments(
+  postId: number,
+  params?: { page?: number; page_size?: number },
+): Promise<CommentsResponse> {
+  const { data } = await publicApi.get<CommentsResponse>(
+    `${API_BASE}/${postId}/comments`,
+    { params },
+  );
+  return data;
+}
+
+/** 댓글 작성 */
+export async function createComment(
+  postId: number,
+  body: CreateCommentRequest,
+): Promise<{ detail: string }> {
+  const { data } = await authApi.post<{ detail: string }>(
+    `${API_BASE}/${postId}/comments`,
+    body,
+  );
+  return data;
+}
+
+/** 댓글 수정 */
+export async function updateComment(
+  postId: number,
+  commentId: number,
+  body: UpdateCommentRequest,
+): Promise<{ id: number; content: string; updated_at: string }> {
+  const { data } = await authApi.put<{
+    id: number;
+    content: string;
+    updated_at: string;
+  }>(`${API_BASE}/${postId}/comments/${commentId}`, body);
+  return data;
+}
+
+/** 댓글 삭제 */
+export async function deleteComment(
+  postId: number,
+  commentId: number,
+): Promise<{ detail: string }> {
+  const { data } = await authApi.delete<{ detail: string }>(
+    `${API_BASE}/${postId}/comments/${commentId}`,
+  );
+  return data;
+}
+
+/** 좋아요 */
+export async function likePost(postId: number): Promise<LikeResponse> {
+  const { data } = await authApi.post<LikeResponse>(
+    `${API_BASE}/${postId}/like`,
+  );
+  return data;
+}
+
+/** 좋아요 취소 */
+export async function unlikePost(postId: number): Promise<LikeResponse> {
+  const { data } = await authApi.delete<LikeResponse>(
+    `${API_BASE}/${postId}/like`,
+  );
+  return data;
+}

--- a/src/mocks/communityDetailHandlers.ts
+++ b/src/mocks/communityDetailHandlers.ts
@@ -1,0 +1,152 @@
+import { http, HttpResponse } from 'msw';
+import type {
+  PostDetail,
+  CommentsResponse,
+  Comment,
+} from '../pages/CommunityDetail/lib/types';
+
+const MOCK_POST: PostDetail = {
+  id: 1,
+  title: '프론트엔드 개발자 취업 준비 팁 공유합니다',
+  author: {
+    id: 1,
+    nickname: '김개발',
+    profile_img_url: '',
+  },
+  category: {
+    id: 1,
+    name: '자유 게시판',
+  },
+  content:
+    '안녕하세요, 최근 프론트엔드 개발자로 취업에 성공한 김개발입니다.\n\n제가 준비하면서 도움이 되었던 내용들을 정리해봤습니다. 포트폴리오는 2~3개 프로젝트를 깊이 있게 만드는 것이 중요하고, 기술 면접에서는 JavaScript 기초와 React 동작 원리를 많이 물어봤습니다.\n\n도움이 되셨으면 좋겠습니다. 궁금한 점 있으면 댓글로 남겨주세요!',
+  view_count: 128,
+  like_count: 15,
+  created_at: '2025-03-15T09:00:00+09:00',
+  updated_at: '2025-03-15T09:00:00+09:00',
+};
+
+let mockComments: Comment[] = [
+  {
+    id: 1,
+    author: {
+      id: 2,
+      nickname: '이수강',
+      profile_img_url: '',
+    },
+    tagged_users: [],
+    content: '좋은 글 감사합니다! 많은 도움이 되었어요.',
+    created_at: '2025-03-15T10:00:00+09:00',
+    updated_at: '2025-03-15T10:00:00+09:00',
+  },
+  {
+    id: 2,
+    author: {
+      id: 3,
+      nickname: '박코딩',
+      profile_img_url: '',
+    },
+    tagged_users: [],
+    content: '저도 비슷한 경험을 했는데 공감이 됩니다.',
+    created_at: '2025-03-15T11:00:00+09:00',
+    updated_at: '2025-03-15T11:00:00+09:00',
+  },
+];
+
+let nextCommentId = 3;
+
+export const communityDetailHandlers = [
+  // 게시글 상세 조회
+  http.get('/api/v1/posts/:postId', ({ params }) => {
+    const postId = Number(params.postId);
+    if (Number.isNaN(postId)) {
+      return HttpResponse.json(
+        { error_detail: '게시글을 찾을 수 없습니다.' },
+        { status: 404 },
+      );
+    }
+    return HttpResponse.json({ ...MOCK_POST, id: postId });
+  }),
+
+  // 게시글 삭제
+  http.delete('/api/v1/posts/:postId', () => {
+    return HttpResponse.json({ detail: '게시글이 삭제되었습니다.' });
+  }),
+
+  // 댓글 목록 조회
+  http.get('/api/v1/posts/:postId/comments', () => {
+    const response: CommentsResponse = {
+      count: mockComments.length,
+      next: null,
+      previous: null,
+      results: mockComments,
+    };
+    return HttpResponse.json(response);
+  }),
+
+  // 댓글 작성
+  http.post('/api/v1/posts/:postId/comments', async ({ request }) => {
+    const body = (await request.json()) as { content: string };
+    const newComment: Comment = {
+      id: nextCommentId++,
+      author: {
+        id: 1,
+        nickname: '김개발',
+        profile_img_url: '',
+      },
+      tagged_users: [],
+      content: body.content,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    };
+    mockComments = [newComment, ...mockComments];
+    return HttpResponse.json(
+      { detail: '댓글이 등록되었습니다.' },
+      { status: 201 },
+    );
+  }),
+
+  // 댓글 수정
+  http.put(
+    '/api/v1/posts/:postId/comments/:commentId',
+    async ({ params, request }) => {
+      const commentId = Number(params.commentId);
+      const body = (await request.json()) as { content: string };
+      const comment = mockComments.find((c) => c.id === commentId);
+      if (!comment) {
+        return HttpResponse.json(
+          { error_detail: '해당 댓글을 찾을 수 없습니다.' },
+          { status: 404 },
+        );
+      }
+      comment.content = body.content;
+      comment.updated_at = new Date().toISOString();
+      return HttpResponse.json({
+        id: comment.id,
+        content: comment.content,
+        updated_at: comment.updated_at,
+      });
+    },
+  ),
+
+  // 댓글 삭제
+  http.delete('/api/v1/posts/:postId/comments/:commentId', ({ params }) => {
+    const commentId = Number(params.commentId);
+    mockComments = mockComments.filter((c) => c.id !== commentId);
+    return HttpResponse.json({ detail: '댓글이 삭제되었습니다.' });
+  }),
+
+  // 좋아요
+  http.post('/api/v1/posts/:postId/like', () => {
+    MOCK_POST.like_count += 1;
+    return HttpResponse.json(
+      { detail: '좋아요가 등록되었습니다.' },
+      { status: 201 },
+    );
+  }),
+
+  // 좋아요 취소
+  http.delete('/api/v1/posts/:postId/like', () => {
+    MOCK_POST.like_count = Math.max(0, MOCK_POST.like_count - 1);
+    return HttpResponse.json({ detail: '좋아요가 취소되었습니다.' });
+  }),
+];

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,5 +1,6 @@
 import { http, passthrough } from 'msw';
 import { communityHandlers } from './communityHandlers';
+import { communityDetailHandlers } from './communityDetailHandlers';
 import { deployedApiPatterns } from './passthrough';
 
 /**
@@ -13,4 +14,5 @@ const passthroughHandlers = deployedApiPatterns.map((pattern) =>
 export const handlers = [
   ...passthroughHandlers,
   ...communityHandlers,
+  ...communityDetailHandlers,
 ];

--- a/src/pages/CommunityDetail/CommunityDetailPage.tsx
+++ b/src/pages/CommunityDetail/CommunityDetailPage.tsx
@@ -1,180 +1,149 @@
-// Figma: https://www.figma.com/design/4rJmEFUU2HMWVy3qUcYZRs/%EC%A0%9C%EB%AA%A9-%EC%97%86%EC%9D%8C?node-id=1-10472&m=dev
+// Figma: https://www.figma.com/design/4rJmEFUU2HMWVy3qUcYZRs/%EC%A0%9C%EB%AA%A9-%EC%97%86%EC%9D%8C?node-id=1-10472
 // Figma-states: communityDetail
-import { type FormEvent, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
-import { Header } from "../../shared/ui/Header/Header";
-import { Footer } from "../../shared/ui/Footer/Footer";
-import { CommentInput } from "../../shared/ui/CommentInput/CommentInput";
-import { CommentSubmitButton } from "../../shared/ui/CommentSubmitButton/CommentSubmitButton";
-import { Button } from "../../shared/ui/Button/Button";
-import { ConfirmModal } from "../../shared/ui/Modal/Modal";
-import { SortModal } from "../../shared/ui/SortModal/SortModal";
+import { useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { Header } from '../../shared/ui/Header/Header';
+import { Footer } from '../../shared/ui/Footer/Footer';
+import { ConfirmModal } from '../../shared/ui/Modal/Modal';
+import { Loading } from '../../shared/ui/Loading/Loading';
+import { PostHeader } from './ui/PostHeader';
+import { PostContent } from './ui/PostContent';
+import { CommentSection } from './ui/CommentSection';
+import {
+  usePostDetailQuery,
+  useCommentsQuery,
+} from './lib/communityDetailQueries';
+import {
+  useDeletePost,
+  useLikePost,
+  useUnlikePost,
+} from './model/useCommunityDetailActions';
+import {
+  useCreateComment,
+  useUpdateComment,
+  useDeleteComment,
+} from './model/useCommentActions';
 
-interface Comment {
-  id: number;
-  author: string;
-  date: string;
-  content: string;
+function getCurrentUserId(): number | null {
+  const token = localStorage.getItem('accessToken');
+  if (!token) return null;
+  try {
+    const parts = token.split('.');
+    if (!parts[1]) return null;
+    const payload = JSON.parse(atob(parts[1]));
+    return payload.user_id ?? null;
+  } catch {
+    return null;
+  }
 }
 
-const MOCK_COMMENTS: Comment[] = [
-  {
-    id: 1,
-    author: "이수강",
-    date: "2025-03-15",
-    content: "좋은 글 감사합니다! 많은 도움이 되었어요.",
-  },
-  {
-    id: 2,
-    author: "박코딩",
-    date: "2025-03-15",
-    content: "저도 비슷한 경험을 했는데 공감이 됩니다.",
-  },
-];
-
-const SORT_OPTIONS = [
-  { label: "최신순", value: "latest" },
-  { label: "오래된순", value: "oldest" },
-];
-
 export function CommunityDetailPage() {
-  const { postId } = useParams<{ postId: string }>();
+  const { postId: postIdParam } = useParams<{ postId: string }>();
   const navigate = useNavigate();
-  const [comment, setComment] = useState("");
+  const postId = Number(postIdParam);
+
   const [showDeleteModal, setShowDeleteModal] = useState(false);
-  const [commentSort, setCommentSort] = useState("latest");
 
-  const isAuthor = true;
-  const isLoggedIn = true;
+  const currentUserId = getCurrentUserId();
+  const isLoggedIn = currentUserId !== null;
 
-  const handleDelete = () => {
+  const { data: post, isLoading: isPostLoading } = usePostDetailQuery(postId);
+  const { data: commentsData, isLoading: isCommentsLoading } =
+    useCommentsQuery(postId);
+
+  const deletePostMutation = useDeletePost(postId);
+  const likePostMutation = useLikePost(postId);
+  const unlikePostMutation = useUnlikePost(postId);
+  const createCommentMutation = useCreateComment(postId);
+  const updateCommentMutation = useUpdateComment(postId);
+  const deleteCommentMutation = useDeleteComment(postId);
+
+  const isAuthor = post ? currentUserId === post.author.id : false;
+
+  const handleDeletePost = () => {
     setShowDeleteModal(false);
-    navigate("/community");
+    deletePostMutation.mutate();
   };
 
-  const handleCommentSubmit = (e: FormEvent) => {
-    e.preventDefault();
-    if (comment.trim().length === 0) return;
-    setComment("");
+  const handleLikeToggle = () => {
+    if (!isLoggedIn) return;
+    likePostMutation.mutate(undefined, {
+      onError: () => {
+        unlikePostMutation.mutate();
+      },
+    });
   };
+
+  if (isPostLoading) {
+    return (
+      <div className="min-h-screen flex flex-col">
+        <Header variant={isLoggedIn ? 'registered' : 'guest'} />
+        <main className="flex-1 flex items-center justify-center">
+          <Loading />
+        </main>
+        <Footer />
+      </div>
+    );
+  }
+
+  if (!post) {
+    return (
+      <div className="min-h-screen flex flex-col">
+        <Header variant={isLoggedIn ? 'registered' : 'guest'} />
+        <main className="flex-1 flex items-center justify-center">
+          <p className="text-gray-500">게시글을 찾을 수 없습니다.</p>
+        </main>
+        <Footer />
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen flex flex-col">
-      <Header variant="registered" />
+      <Header variant={isLoggedIn ? 'registered' : 'guest'} />
       <main className="flex-1 flex justify-center py-10">
         <div className="flex flex-col gap-8 w-300">
-          {/* Post header */}
-          <div className="flex flex-col gap-4">
-            <h1 className="text-2xl font-bold leading-snug tracking-tight text-gray-primary">
-              프론트엔드 개발자 취업 준비 팁 공유합니다
-            </h1>
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-3">
-                <div className="w-10 h-10 rounded-full bg-gray-200" />
-                <div className="flex flex-col">
-                  <span className="text-sm font-semibold leading-snug tracking-tight text-gray-primary">
-                    김개발
-                  </span>
-                  <span className="text-xs leading-snug tracking-tight text-gray-400">
-                    2025-03-15
-                  </span>
-                </div>
-              </div>
-              {isAuthor && (
-                <div className="flex items-center gap-2">
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() =>
-                      navigate(`/community/${postId}/edit`)
-                    }
-                  >
-                    수정
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => setShowDeleteModal(true)}
-                  >
-                    삭제
-                  </Button>
-                </div>
-              )}
-            </div>
-          </div>
+          <PostHeader
+            post={post}
+            isAuthor={isAuthor}
+            onEdit={() => navigate(`/community/${postId}/edit`)}
+            onDelete={() => setShowDeleteModal(true)}
+          />
 
-          {/* Divider */}
           <div className="w-full h-px bg-gray-200" />
 
-          {/* Post content */}
-          <div className="text-base leading-relaxed tracking-tight text-gray-700 min-h-50">
-            <p>
-              안녕하세요, 최근 프론트엔드 개발자로 취업에 성공한 김개발입니다.
-            </p>
-            <p className="mt-4">
-              제가 준비하면서 도움이 되었던 내용들을 정리해봤습니다.
-              포트폴리오는 2~3개 프로젝트를 깊이 있게 만드는 것이 중요하고,
-              기술 면접에서는 JavaScript 기초와 React 동작 원리를
-              많이 물어봤습니다.
-            </p>
-            <p className="mt-4">
-              도움이 되셨으면 좋겠습니다. 궁금한 점 있으면 댓글로 남겨주세요!
-            </p>
-          </div>
+          <PostContent
+            content={post.content}
+            likeCount={post.like_count}
+            viewCount={post.view_count}
+            isLoggedIn={isLoggedIn}
+            onLikeToggle={handleLikeToggle}
+            isLikeLoading={
+              likePostMutation.isPending || unlikePostMutation.isPending
+            }
+          />
 
-          {/* Divider */}
           <div className="w-full h-px bg-gray-200" />
 
-          {/* Comments section */}
-          <div className="flex flex-col gap-5">
-            <div className="flex items-center justify-between">
-              <p className="text-base font-semibold leading-snug tracking-tight text-gray-primary">
-                댓글 {MOCK_COMMENTS.length}
-              </p>
-              <SortModal
-                options={SORT_OPTIONS}
-                value={commentSort}
-                onChange={setCommentSort}
-              />
-            </div>
-
-            {/* Comment input */}
-            {isLoggedIn && (
-              <form onSubmit={handleCommentSubmit} className="flex flex-col gap-2 items-end">
-                <CommentInput
-                  value={comment}
-                  onChange={setComment}
-                />
-                <CommentSubmitButton
-                  type="submit"
-                  disabled={comment.trim().length === 0}
-                />
-              </form>
-            )}
-
-            {/* Comment list */}
-            <div className="flex flex-col gap-4">
-              {MOCK_COMMENTS.map((c) => (
-                <div
-                  key={c.id}
-                  className="flex flex-col gap-2 p-4 rounded-sm border border-gray-200"
-                >
-                  <div className="flex items-center gap-2">
-                    <div className="w-8 h-8 rounded-full bg-gray-200" />
-                    <span className="text-sm font-semibold leading-snug tracking-tight text-gray-primary">
-                      {c.author}
-                    </span>
-                    <span className="text-xs leading-snug tracking-tight text-gray-400">
-                      {c.date}
-                    </span>
-                  </div>
-                  <p className="text-sm leading-relaxed tracking-tight text-gray-700">
-                    {c.content}
-                  </p>
-                </div>
-              ))}
-            </div>
-          </div>
+          <CommentSection
+            comments={commentsData?.results ?? []}
+            totalCount={commentsData?.count ?? 0}
+            isLoading={isCommentsLoading}
+            isLoggedIn={isLoggedIn}
+            currentUserId={currentUserId}
+            onCreateComment={(content) =>
+              createCommentMutation.mutate(content)
+            }
+            onUpdateComment={(commentId, content) =>
+              updateCommentMutation.mutate({ commentId, content })
+            }
+            onDeleteComment={(commentId) =>
+              deleteCommentMutation.mutate(commentId)
+            }
+            isCreating={createCommentMutation.isPending}
+            isUpdating={updateCommentMutation.isPending}
+            isDeleting={deleteCommentMutation.isPending}
+          />
         </div>
       </main>
       <Footer />
@@ -184,7 +153,7 @@ export function CommunityDetailPage() {
         message="정말 이 게시글을 삭제하시겠습니까?"
         confirmLabel="삭제"
         cancelLabel="취소"
-        onConfirm={handleDelete}
+        onConfirm={handleDeletePost}
         onCancel={() => setShowDeleteModal(false)}
       />
     </div>

--- a/src/pages/CommunityDetail/lib/communityDetailQueries.ts
+++ b/src/pages/CommunityDetail/lib/communityDetailQueries.ts
@@ -1,0 +1,37 @@
+// Figma: https://www.figma.com/design/4rJmEFUU2HMWVy3qUcYZRs/%EC%A0%9C%EB%AA%A9-%EC%97%86%EC%9D%8C?node-id=1-10472
+// Figma-states: communityDetail
+
+import { queryOptions, useQuery } from '@tanstack/react-query';
+import { fetchPostDetail, fetchComments } from '../../../api/communityDetail';
+
+export const communityDetailQueries = {
+  all: () => ['communityDetail'] as const,
+
+  detail: (postId: number) =>
+    queryOptions({
+      queryKey: [...communityDetailQueries.all(), 'detail', postId] as const,
+      queryFn: () => fetchPostDetail(postId),
+      enabled: postId > 0,
+    }),
+
+  comments: (postId: number, page = 1, pageSize = 100) =>
+    queryOptions({
+      queryKey: [
+        ...communityDetailQueries.all(),
+        'comments',
+        postId,
+        page,
+        pageSize,
+      ] as const,
+      queryFn: () => fetchComments(postId, { page, page_size: pageSize }),
+      enabled: postId > 0,
+    }),
+};
+
+export function usePostDetailQuery(postId: number) {
+  return useQuery(communityDetailQueries.detail(postId));
+}
+
+export function useCommentsQuery(postId: number, page = 1, pageSize = 100) {
+  return useQuery(communityDetailQueries.comments(postId, page, pageSize));
+}

--- a/src/pages/CommunityDetail/lib/constants.ts
+++ b/src/pages/CommunityDetail/lib/constants.ts
@@ -1,0 +1,9 @@
+// Figma: https://www.figma.com/design/4rJmEFUU2HMWVy3qUcYZRs/%EC%A0%9C%EB%AA%A9-%EC%97%86%EC%9D%8C?node-id=1-10472
+// Figma-states: communityDetail
+
+export const SORT_OPTIONS = [
+  { label: '최신순', value: 'latest' },
+  { label: '오래된순', value: 'oldest' },
+] as const;
+
+export const COMMENT_MAX_LENGTH = 500;

--- a/src/pages/CommunityDetail/lib/types.ts
+++ b/src/pages/CommunityDetail/lib/types.ts
@@ -1,0 +1,68 @@
+// Figma: https://www.figma.com/design/4rJmEFUU2HMWVy3qUcYZRs/%EC%A0%9C%EB%AA%A9-%EC%97%86%EC%9D%8C?node-id=1-10472
+// Figma-states: communityDetail
+
+export interface PostAuthor {
+  id: number;
+  nickname: string;
+  profile_img_url: string;
+}
+
+export interface PostCategory {
+  id: number;
+  name: string;
+}
+
+export interface PostDetail {
+  id: number;
+  title: string;
+  author: PostAuthor;
+  category: PostCategory;
+  content: string;
+  view_count: number;
+  like_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CommentAuthor {
+  id: number;
+  nickname: string;
+  profile_img_url: string;
+}
+
+export interface TaggedUser {
+  id: number;
+  nickname: string;
+}
+
+export interface Comment {
+  id: number;
+  author: CommentAuthor;
+  tagged_users: TaggedUser[];
+  content: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CommentsResponse {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: Comment[];
+}
+
+export interface CreateCommentRequest {
+  content: string;
+}
+
+export interface UpdateCommentRequest {
+  content: string;
+}
+
+export interface DeletePostResponse {
+  detail: string;
+}
+
+export interface LikeResponse {
+  detail: string;
+}

--- a/src/pages/CommunityDetail/model/useCommentActions.ts
+++ b/src/pages/CommunityDetail/model/useCommentActions.ts
@@ -1,0 +1,55 @@
+// Figma: https://www.figma.com/design/4rJmEFUU2HMWVy3qUcYZRs/%EC%A0%9C%EB%AA%A9-%EC%97%86%EC%9D%8C?node-id=1-10472
+// Figma-states: communityDetail
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  createComment,
+  updateComment,
+  deleteComment,
+} from '../../../api/communityDetail';
+import { communityDetailQueries } from '../lib/communityDetailQueries';
+
+export function useCreateComment(postId: number) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (content: string) => createComment(postId, { content }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: communityDetailQueries.comments(postId).queryKey,
+      });
+    },
+  });
+}
+
+export function useUpdateComment(postId: number) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      commentId,
+      content,
+    }: {
+      commentId: number;
+      content: string;
+    }) => updateComment(postId, commentId, { content }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: communityDetailQueries.comments(postId).queryKey,
+      });
+    },
+  });
+}
+
+export function useDeleteComment(postId: number) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (commentId: number) => deleteComment(postId, commentId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: communityDetailQueries.comments(postId).queryKey,
+      });
+    },
+  });
+}

--- a/src/pages/CommunityDetail/model/useCommunityDetailActions.ts
+++ b/src/pages/CommunityDetail/model/useCommunityDetailActions.ts
@@ -1,0 +1,48 @@
+// Figma: https://www.figma.com/design/4rJmEFUU2HMWVy3qUcYZRs/%EC%A0%9C%EB%AA%A9-%EC%97%86%EC%9D%8C?node-id=1-10472
+// Figma-states: communityDetail
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import { deletePost, likePost, unlikePost } from '../../../api/communityDetail';
+import { communityDetailQueries } from '../lib/communityDetailQueries';
+
+export function useDeletePost(postId: number) {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => deletePost(postId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: communityDetailQueries.all(),
+      });
+      navigate('/community');
+    },
+  });
+}
+
+export function useLikePost(postId: number) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => likePost(postId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: communityDetailQueries.detail(postId).queryKey,
+      });
+    },
+  });
+}
+
+export function useUnlikePost(postId: number) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => unlikePost(postId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: communityDetailQueries.detail(postId).queryKey,
+      });
+    },
+  });
+}

--- a/src/pages/CommunityDetail/ui/CommentCard.tsx
+++ b/src/pages/CommunityDetail/ui/CommentCard.tsx
@@ -1,0 +1,117 @@
+// Figma: https://www.figma.com/design/4rJmEFUU2HMWVy3qUcYZRs/%EC%A0%9C%EB%AA%A9-%EC%97%86%EC%9D%8C?node-id=1-10472
+// Figma-states: communityDetail
+
+import { useState, type FormEvent } from 'react';
+import { ProfileImage } from '../../../shared/ui/ProfileImage/ProfileImage';
+import { CommentInput } from '../../../shared/ui/CommentInput/CommentInput';
+import { CommentSubmitButton } from '../../../shared/ui/CommentSubmitButton/CommentSubmitButton';
+import type { Comment } from '../lib/types';
+import { COMMENT_MAX_LENGTH } from '../lib/constants';
+
+interface CommentCardProps {
+  comment: Comment;
+  currentUserId: number | null;
+  onUpdate: (commentId: number, content: string) => void;
+  onDelete: (commentId: number) => void;
+  isUpdating: boolean;
+  isDeleting: boolean;
+}
+
+export function CommentCard({
+  comment,
+  currentUserId,
+  onUpdate,
+  onDelete,
+  isUpdating,
+  isDeleting,
+}: CommentCardProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editContent, setEditContent] = useState(comment.content);
+
+  const isAuthor = currentUserId === comment.author.id;
+
+  const formattedDate = new Date(comment.created_at).toLocaleDateString(
+    'ko-KR',
+    { year: 'numeric', month: '2-digit', day: '2-digit' },
+  );
+
+  const handleEditSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    if (editContent.trim().length === 0) return;
+    if (editContent.length > COMMENT_MAX_LENGTH) return;
+    onUpdate(comment.id, editContent.trim());
+    setIsEditing(false);
+  };
+
+  const handleCancelEdit = () => {
+    setEditContent(comment.content);
+    setIsEditing(false);
+  };
+
+  return (
+    <div className="flex flex-col gap-2 p-4 rounded-sm border border-gray-200">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <ProfileImage
+            src={comment.author.profile_img_url}
+            alt={`${comment.author.nickname} 프로필`}
+            size="sm"
+          />
+          <span className="text-sm font-semibold leading-snug tracking-tight text-gray-primary">
+            {comment.author.nickname}
+          </span>
+          <span className="text-xs leading-snug tracking-tight text-gray-400">
+            {formattedDate}
+          </span>
+        </div>
+        {isAuthor && !isEditing && (
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setIsEditing(true)}
+              className="text-xs text-gray-400 hover:text-gray-600 cursor-pointer transition-colors"
+            >
+              수정
+            </button>
+            <button
+              type="button"
+              onClick={() => onDelete(comment.id)}
+              disabled={isDeleting}
+              className="text-xs text-gray-400 hover:text-danger cursor-pointer transition-colors disabled:cursor-not-allowed"
+            >
+              삭제
+            </button>
+          </div>
+        )}
+      </div>
+
+      {isEditing ? (
+        <form onSubmit={handleEditSubmit} className="flex flex-col gap-2 items-end">
+          <CommentInput value={editContent} onChange={setEditContent} />
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={handleCancelEdit}
+              className="px-4 py-2 text-sm text-gray-500 hover:text-gray-700 cursor-pointer transition-colors"
+            >
+              취소
+            </button>
+            <CommentSubmitButton
+              label="수정"
+              onClick={() => handleEditSubmit({ preventDefault: () => {} } as FormEvent)}
+              disabled={
+                editContent.trim().length === 0 ||
+                editContent.length > COMMENT_MAX_LENGTH ||
+                isUpdating
+              }
+            />
+          </div>
+        </form>
+      ) : (
+        <p className="text-sm leading-relaxed tracking-tight text-gray-700">
+          {comment.content}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/pages/CommunityDetail/ui/CommentSection.tsx
+++ b/src/pages/CommunityDetail/ui/CommentSection.tsx
@@ -1,0 +1,112 @@
+// Figma: https://www.figma.com/design/4rJmEFUU2HMWVy3qUcYZRs/%EC%A0%9C%EB%AA%A9-%EC%97%86%EC%9D%8C?node-id=1-10472
+// Figma-states: communityDetail
+
+import { useState, type FormEvent } from 'react';
+import { CommentInput } from '../../../shared/ui/CommentInput/CommentInput';
+import { CommentSubmitButton } from '../../../shared/ui/CommentSubmitButton/CommentSubmitButton';
+import { SortModal } from '../../../shared/ui/SortModal/SortModal';
+import { Loading } from '../../../shared/ui/Loading/Loading';
+import { CommentCard } from './CommentCard';
+import { SORT_OPTIONS, COMMENT_MAX_LENGTH } from '../lib/constants';
+import type { Comment } from '../lib/types';
+
+interface CommentSectionProps {
+  comments: Comment[];
+  totalCount: number;
+  isLoading: boolean;
+  isLoggedIn: boolean;
+  currentUserId: number | null;
+  onCreateComment: (content: string) => void;
+  onUpdateComment: (commentId: number, content: string) => void;
+  onDeleteComment: (commentId: number) => void;
+  isCreating: boolean;
+  isUpdating: boolean;
+  isDeleting: boolean;
+}
+
+export function CommentSection({
+  comments,
+  totalCount,
+  isLoading,
+  isLoggedIn,
+  currentUserId,
+  onCreateComment,
+  onUpdateComment,
+  onDeleteComment,
+  isCreating,
+  isUpdating,
+  isDeleting,
+}: CommentSectionProps) {
+  const [newComment, setNewComment] = useState('');
+  const [commentSort, setCommentSort] = useState('latest');
+
+  const handleCommentSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    if (newComment.trim().length === 0) return;
+    if (newComment.length > COMMENT_MAX_LENGTH) return;
+    onCreateComment(newComment.trim());
+    setNewComment('');
+  };
+
+  const sortedComments = [...comments].sort((a, b) => {
+    if (commentSort === 'oldest') {
+      return new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
+    }
+    return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+  });
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="flex items-center justify-between">
+        <p className="text-base font-semibold leading-snug tracking-tight text-gray-primary">
+          댓글 {totalCount}
+        </p>
+        <SortModal
+          options={[...SORT_OPTIONS]}
+          value={commentSort}
+          onChange={setCommentSort}
+        />
+      </div>
+
+      {isLoggedIn && (
+        <form
+          onSubmit={handleCommentSubmit}
+          className="flex flex-col gap-2 items-end"
+        >
+          <CommentInput value={newComment} onChange={setNewComment} />
+          <CommentSubmitButton
+            type="submit"
+            disabled={
+              newComment.trim().length === 0 ||
+              newComment.length > COMMENT_MAX_LENGTH ||
+              isCreating
+            }
+          />
+        </form>
+      )}
+
+      {isLoading ? (
+        <Loading className="py-10" />
+      ) : (
+        <div className="flex flex-col gap-4">
+          {sortedComments.map((comment) => (
+            <CommentCard
+              key={comment.id}
+              comment={comment}
+              currentUserId={currentUserId}
+              onUpdate={onUpdateComment}
+              onDelete={onDeleteComment}
+              isUpdating={isUpdating}
+              isDeleting={isDeleting}
+            />
+          ))}
+          {sortedComments.length === 0 && (
+            <p className="text-center text-sm text-gray-400 py-8">
+              아직 댓글이 없습니다. 첫 댓글을 남겨보세요.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/CommunityDetail/ui/PostContent.tsx
+++ b/src/pages/CommunityDetail/ui/PostContent.tsx
@@ -1,0 +1,91 @@
+// Figma: https://www.figma.com/design/4rJmEFUU2HMWVy3qUcYZRs/%EC%A0%9C%EB%AA%A9-%EC%97%86%EC%9D%8C?node-id=1-10472
+// Figma-states: communityDetail
+
+interface PostContentProps {
+  content: string;
+  likeCount: number;
+  viewCount: number;
+  isLoggedIn: boolean;
+  onLikeToggle: () => void;
+  isLikeLoading: boolean;
+}
+
+export function PostContent({
+  content,
+  likeCount,
+  viewCount,
+  isLoggedIn,
+  onLikeToggle,
+  isLikeLoading,
+}: PostContentProps) {
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="text-base leading-relaxed tracking-tight text-gray-700 min-h-50 whitespace-pre-wrap">
+        {content}
+      </div>
+
+      <div className="flex items-center gap-4">
+        <button
+          type="button"
+          onClick={onLikeToggle}
+          disabled={!isLoggedIn || isLikeLoading}
+          className="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-primary transition-colors cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <HeartIcon />
+          <span>좋아요 {likeCount}</span>
+        </button>
+        <span className="inline-flex items-center gap-1 text-sm text-gray-500">
+          <EyeIcon />
+          <span>조회 {viewCount}</span>
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function HeartIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M8 14s-5.5-3.5-5.5-7A3.5 3.5 0 0 1 8 4.5 3.5 3.5 0 0 1 13.5 7C13.5 10.5 8 14 8 14z"
+        stroke="currentColor"
+        strokeWidth="1.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function EyeIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M1 8s2.5-5 7-5 7 5 7 5-2.5 5-7 5-7-5-7-5z"
+        stroke="currentColor"
+        strokeWidth="1.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <circle
+        cx="8"
+        cy="8"
+        r="2"
+        stroke="currentColor"
+        strokeWidth="1.2"
+      />
+    </svg>
+  );
+}

--- a/src/pages/CommunityDetail/ui/PostHeader.tsx
+++ b/src/pages/CommunityDetail/ui/PostHeader.tsx
@@ -1,0 +1,61 @@
+// Figma: https://www.figma.com/design/4rJmEFUU2HMWVy3qUcYZRs/%EC%A0%9C%EB%AA%A9-%EC%97%86%EC%9D%8C?node-id=1-10472
+// Figma-states: communityDetail
+
+import { ProfileImage } from '../../../shared/ui/ProfileImage/ProfileImage';
+import { Button } from '../../../shared/ui/Button/Button';
+import type { PostDetail } from '../lib/types';
+
+interface PostHeaderProps {
+  post: PostDetail;
+  isAuthor: boolean;
+  onEdit: () => void;
+  onDelete: () => void;
+}
+
+export function PostHeader({
+  post,
+  isAuthor,
+  onEdit,
+  onDelete,
+}: PostHeaderProps) {
+  const formattedDate = new Date(post.created_at).toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+
+  return (
+    <div className="flex flex-col gap-4">
+      <h1 className="text-2xl font-bold leading-snug tracking-tight text-gray-primary">
+        {post.title}
+      </h1>
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <ProfileImage
+            src={post.author.profile_img_url}
+            alt={`${post.author.nickname} 프로필`}
+            size="md"
+          />
+          <div className="flex flex-col">
+            <span className="text-sm font-semibold leading-snug tracking-tight text-gray-primary">
+              {post.author.nickname}
+            </span>
+            <span className="text-xs leading-snug tracking-tight text-gray-400">
+              {formattedDate}
+            </span>
+          </div>
+        </div>
+        {isAuthor && (
+          <div className="flex items-center gap-2">
+            <Button variant="ghost" size="sm" onClick={onEdit}>
+              수정
+            </Button>
+            <Button variant="ghost" size="sm" onClick={onDelete}>
+              삭제
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #32

## 변경사항
- CommunityDetail 페이지를 FSD 구조로 리팩토링 (ui/, model/, lib/)
- mock 데이터 기반 정적 UI에서 실제 API 연동으로 전환
- TanStack Query Factory Pattern으로 게시글 상세 조회 및 댓글 목록 조회
- 댓글 CRUD (작성/수정/삭제) mutation hooks
- 게시글 삭제 및 좋아요 토글 mutation hooks
- MSW 핸들러 작성 (게시글 상세, 댓글 CRUD, 좋아요)
- 컴포넌트 200줄 이하 유지

## 구조
```
src/pages/CommunityDetail/
  CommunityDetailPage.tsx     (메인 페이지 - 조합)
  lib/
    types.ts                  (API 응답/요청 타입)
    constants.ts              (정렬 옵션, 댓글 제한)
    communityDetailQueries.ts (TanStack Query Factory)
  model/
    useCommunityDetailActions.ts (게시글 삭제, 좋아요)
    useCommentActions.ts         (댓글 CRUD)
  ui/
    PostHeader.tsx             (제목, 작성자, 수정/삭제)
    PostContent.tsx            (본문, 좋아요, 조회수)
    CommentCard.tsx            (댓글 카드 + 인라인 수정)
    CommentSection.tsx         (댓글 목록 + 작성 폼)
```