### PR TITLE
feat: 모든 Gate 머지 전 강제 검증

### DIFF
--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -133,7 +133,10 @@ bash .claude/hooks/gates/figma-sync.sh "FIGMA_URL"
 3. **사용자 확인**: spec 내용 확인 대기
 4. **전이**: → GATE_1
 
-### GATE_1
+### GATE_1 (절대 스킵 금지)
+
+> **🚫 이 Gate는 어떤 경우에도 스킵할 수 없다. merge-guard.sh가 gateResults.gate1을 검증한다.**
+
 **스크립트 실행**:
 ```bash
 bash .claude/hooks/gates/gate1-spec.sh docs/SPEC.md
@@ -142,9 +145,11 @@ bash .claude/hooks/gates/gate1-spec.sh docs/SPEC.md
 **결과 처리**:
 | 결과 | 행동 |
 |------|------|
-| `pass: true` | → PLAN |
+| `pass: true` | `gateResults.gate1: "pass"` 기록 → PLAN |
 | `pass: false` | `spec-reviewer` 에이전트 호출 → 수정 → 재실행 (최대 3회) |
 | 3회 실패 | 사용자에게 판단 위임 |
+
+**완료 시 반드시**: `workflow-state.json`의 `gateResults.gate1`을 `"pass"` 또는 `"fail"`로 기록.
 
 ### PLAN
 1. `docs/plan.template.md` 기반으로 구현 계획 생성
@@ -168,7 +173,10 @@ plan.md의 각 Step을 순차 실행:
 
 **전이**: 모든 Step 완료 → GATE_2
 
-### GATE_2
+### GATE_2 (절대 스킵 금지)
+
+> **🚫 이 Gate는 어떤 경우에도 스킵할 수 없다. merge-guard.sh가 gateResults.gate2를 검증한다.**
+
 **스크립트 실행**:
 ```bash
 bash .claude/hooks/gates/gate2-quality.sh
@@ -177,14 +185,19 @@ bash .claude/hooks/gates/gate2-quality.sh
 **결과 처리**:
 | 결과 | 행동 |
 |------|------|
-| `pass: true` | → GATE_3 |
+| `pass: true` | `gateResults.gate2: "pass"` 기록 → GATE_3 |
 | `failedChecks: ["lint"]` | `pnpm lint --fix` 자동 실행 → 재검증 |
 | `failedChecks: ["typescript"]` | 타입 에러 수정 → 재검증 |
 | `failedChecks: ["test"]` | 실패 테스트 분석 → 구현 수정 → 재검증 |
 | `failedChecks: ["design-tokens"]` | 하드코딩 색상을 토큰으로 교체 → 재검증 |
 | 3회 실패 | 사용자에게 보고 |
 
-### GATE_3
+**완료 시 반드시**: `workflow-state.json`의 `gateResults.gate2`를 `"pass"` 또는 `"fail"`로 기록.
+
+### GATE_3 (절대 스킵 금지)
+
+> **🚫 이 Gate는 어떤 경우에도 스킵할 수 없다. merge-guard.sh가 gateResults.gate3를 검증한다.**
+
 **스크립트 실행**:
 ```bash
 bash .claude/hooks/gates/gate3-review.sh
@@ -208,10 +221,12 @@ bash .claude/hooks/gates/gate3-review.sh
 리뷰 결과 종합:
 | 이슈 레벨 | 행동 |
 |-----------|------|
-| Critical 0 + Warning 0 | → FIGMA_VERIFY |
+| Critical 0 + Warning 0 | `gateResults.gate3: "pass"` 기록 → FIGMA_VERIFY |
 | Critical > 0 | 자동 수정 시도 → GATE_2 재실행 |
 | Warning > 0 | **사용자 확인**: 수정 여부 결정 |
-| Suggestion만 | PR 코멘트에 포함, → FIGMA_VERIFY |
+| Suggestion만 | `gateResults.gate3: "pass"` 기록, PR 코멘트에 포함 → FIGMA_VERIFY |
+
+**완료 시 반드시**: `workflow-state.json`의 `gateResults.gate3`를 `"pass"` 또는 `"fail"`로 기록.
 
 ### FIGMA_VERIFY (절대 스킵 금지)
 

--- a/.claude/hooks/dev/security-guard.sh
+++ b/.claude/hooks/dev/security-guard.sh
@@ -59,20 +59,27 @@ if echo "$COMMAND" | grep -qE 'npm\s+publish|pnpm\s+publish'; then
   exit 2
 fi
 
-# ── gh pr merge 차단 (FIGMA_VERIFY + PR_REVIEW 필수) ──
+# ── gh pr merge 차단 (모든 Gate 필수) ──
 if echo "$COMMAND" | grep -q 'pr merge'; then
   STATE_FILE=".claude/workflow-state.json"
   if [ ! -f "$STATE_FILE" ]; then
-    echo "🚫 머지 차단: workflow-state.json이 없습니다. FIGMA_VERIFY + PR_REVIEW를 먼저 수행하세요."
+    echo "🚫 머지 차단: workflow-state.json이 없습니다. 전체 워크플로우를 먼저 수행하세요."
     exit 2
   fi
   BLOCK=""
-  # UI 파일 변경 시 FIGMA_VERIFY 필수
-  if git diff main...HEAD --name-only 2>/dev/null | grep -qE '^src/(pages|shared/ui)/'; then
-    FV=$(jq -r '.figmaVerified // false' "$STATE_FILE" 2>/dev/null)
-    [ "$FV" != "true" ] && BLOCK="${BLOCK}FIGMA_VERIFY 미완료. "
-  fi
-  # PR_REVIEW 필수
+  # GATE1: spec 검증 필수
+  G1=$(jq -r '.gateResults.gate1 // "null"' "$STATE_FILE" 2>/dev/null)
+  [ "$G1" = "null" ] && BLOCK="${BLOCK}GATE1(spec 검증) 미실행. "
+  # GATE2: 타입/린트/테스트 검증
+  G2=$(jq -r '.gateResults.gate2 // "null"' "$STATE_FILE" 2>/dev/null)
+  [ "$G2" = "null" ] && BLOCK="${BLOCK}GATE2(품질 검증) 미실행. "
+  # GATE3: 코드 리뷰 에이전트 실행
+  G3=$(jq -r '.gateResults.gate3 // "null"' "$STATE_FILE" 2>/dev/null)
+  [ "$G3" = "null" ] && BLOCK="${BLOCK}GATE3(리뷰 에이전트) 미실행. "
+  # FIGMA_VERIFY: 스크린샷 비교 필수
+  FV=$(jq -r '.figmaVerified // false' "$STATE_FILE" 2>/dev/null)
+  [ "$FV" != "true" ] && BLOCK="${BLOCK}FIGMA_VERIFY(스크린샷 비교) 미완료. "
+  # PR_REVIEW: 인라인 코멘트 필수
   PR=$(jq -r '.prReviewCompleted // false' "$STATE_FILE" 2>/dev/null)
   [ "$PR" != "true" ] && BLOCK="${BLOCK}PR_REVIEW(인라인 코멘트) 미완료. "
   if [ -n "$BLOCK" ]; then


### PR DESCRIPTION
## 개요
GATE1, GATE3가 계속 누락되는 문제 수정. merge-guard에서 모든 Gate를 검증하도록 강제화.

## 변경 사항
- security-guard.sh merge 차단 로직 확장:
  - `gateResults.gate1` (spec 검증) 미실행 시 차단
  - `gateResults.gate2` (품질 검증) 미실행 시 차단
  - `gateResults.gate3` (리뷰 에이전트) 미실행 시 차단
  - `figmaVerified` (스크린샷 비교) 미완료 시 차단
  - `prReviewCompleted` (인라인 코멘트) 미완료 시 차단
- orchestrator.md 모든 Gate에 "절대 스킵 금지" 명시
- 각 Gate 완료 시 workflow-state.json에 결과 기록 강제

## 스크린샷
문서/설정 변경만이므로 해당 없음

## 테스트
- [x] security-guard.sh 로직 검증
- [ ] Gate 미실행 상태에서 merge 시도 → 차단 확인

## 관련 이슈
GATE1/GATE3 누락 문제 후속 수정