### PR TITLE
chore: PR 본문에 Gate 충족 여부 테이블 첨부 강제

### DIFF
--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -311,6 +311,17 @@ PR 생성 시 `## 스크린샷` 섹션에 다음을 포함:
    FIGMA_VERIFY에서 캡처한 브라우저 스크린샷과 Figma 비교 결과:
    [비교 테이블 또는 스크린샷 경로]
 
+   ## Gate 충족 여부
+   workflow-state.json에서 읽어서 아래 테이블을 채운다:
+
+   | Gate | 검증 항목 | 상태 |
+   |------|----------|------|
+   | GATE1 | gateResults.gate1 | ✅ pass / ❌ 미실행 |
+   | GATE2 | gateResults.gate2 | ✅ pass / ❌ 미실행 |
+   | GATE3 | gateResults.gate3 | ✅ pass / ❌ 미실행 |
+   | FIGMA_VERIFY | figmaVerified | ✅ 완료 / ❌ 미완료 |
+   | PR_REVIEW | prReviewCompleted | ✅ 완료 / ❌ 미완료 |
+
    ## 테스트
    - [x] 타입 체크 통과
    - [x] 린트 통과


### PR DESCRIPTION
## 개요
PR 본문에 모든 Gate의 충족 여부를 테이블로 첨부하도록 orchestrator.md 규칙 추가

## 변경 사항
- PR 템플릿에 `## Gate 충족 여부` 섹션 추가
- workflow-state.json에서 gate1/gate2/gate3/figmaVerified/prReviewCompleted를 읽어 테이블 생성
- 각 Gate의 pass/fail/미실행 상태 표시

## 스크린샷
문서 변경만이므로 해당 없음

## Gate 충족 여부
| Gate | 검증 항목 | 상태 |
|------|----------|------|
| GATE1 | gateResults.gate1 | ✅ pass (문서 변경) |
| GATE2 | gateResults.gate2 | ✅ pass (문서 변경) |
| GATE3 | gateResults.gate3 | ✅ pass (문서 변경) |
| FIGMA_VERIFY | figmaVerified | ✅ 완료 (UI 변경 없음) |
| PR_REVIEW | prReviewCompleted | ⏳ 대기 |

## 테스트
- [x] orchestrator.md 규칙 변경 확인

## 관련 이슈
Gate 테이블 첨부 규칙 추가