### PR TITLE
fix: Discord 알림 순서 꼬임 수정

### DIFF
--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -57,7 +57,11 @@ Discord 채널에 작업 과정을 공유하세요:
    bash .claude/hooks/notify-discord.sh "리뷰 완료" "REQUEST_CHANGES — Critical 2, Warning 3" "success|fail" "{agent}"
 ```
 
-Gate 스크립트(gate1/2/3)는 `gate` 프로필로 자체 알림을 전송하므로 orchestrator가 중복 호출하지 않는다.
+### Discord 알림 순서 규칙
+1. Gate 스크립트(gate1/2/3)는 `gate` 프로필로 자체 알림을 전송 → **orchestrator가 중복 호출하지 않는다**
+2. Phase 전환 알림만 orchestrator가 전송 (예: "IMPLEMENT → GATE_2", "PR #42 생성")
+3. 모든 알림은 **동기적**으로 전송한다 (백그라운드 `&` 사용 금지) → 순서 보장
+4. 하나의 Phase가 완전히 끝난 뒤에만 다음 Phase 알림을 전송
 
 ---
 
@@ -151,10 +155,7 @@ echo "$GATE1_RESULT"
 | `pass: false` | `spec-reviewer` 에이전트 호출 → 수정 → 재실행 (최대 3회) |
 | 3회 실패 | 사용자에게 판단 위임 |
 
-**완료 후 반드시 Discord 알림**:
-```bash
-bash .claude/hooks/notify-discord.sh "GATE_1 완료" "결과: pass/fail" "success|fail" "gate"
-```
+**Discord 알림**: Gate 스크립트가 자체적으로 Discord 알림을 전송한다. **orchestrator가 중복 전송하지 않는다.**
 
 **완료 시 반드시**: `workflow-state.json`의 `gateResults.gate1`을 `"pass"` 또는 `"fail"`로 기록.
 
@@ -201,10 +202,7 @@ echo "$GATE2_RESULT"
 | `failedChecks: ["design-tokens"]` | 하드코딩 색상을 토큰으로 교체 → 재검증 |
 | 3회 실패 | 사용자에게 보고 |
 
-**완료 후 반드시 Discord 알림**:
-```bash
-bash .claude/hooks/notify-discord.sh "GATE_2 완료" "TypeScript/ESLint/테스트 결과: pass/fail" "success|fail" "gate"
-```
+**Discord 알림**: Gate 스크립트가 자체적으로 Discord 알림을 전송한다. **orchestrator가 중복 전송하지 않는다.**
 
 **완료 시 반드시**: `workflow-state.json`의 `gateResults.gate2`를 `"pass"` 또는 `"fail"`로 기록.
 
@@ -242,10 +240,7 @@ echo "$GATE3_RESULT"
 | Warning > 0 | **사용자 확인**: 수정 여부 결정 |
 | Suggestion만 | `gateResults.gate3: "pass"` 기록, PR 코멘트에 포함 → FIGMA_VERIFY |
 
-**완료 후 반드시 Discord 알림**:
-```bash
-bash .claude/hooks/notify-discord.sh "GATE_3 완료" "리뷰 에이전트 결과: pass/fail\n에이전트: [목록]" "success|fail" "gate"
-```
+**Discord 알림**: Gate 스크립트가 자체적으로 Discord 알림을 전송한다. **orchestrator가 중복 전송하지 않는다.**
 
 **완료 시 반드시**: `workflow-state.json`의 `gateResults.gate3`를 `"pass"` 또는 `"fail"`로 기록.
 

--- a/.claude/hooks/dev/agent-discord.sh
+++ b/.claude/hooks/dev/agent-discord.sh
@@ -40,11 +40,11 @@ if [ -n "$TOOL_RESULT" ]; then
     COLOR="success"
   fi
 
-  bash "$NOTIFY" "작업 완료: ${DESCRIPTION}" "$RESULT_SUMMARY" "$COLOR" "$DISCORD_AGENT" &
+  bash "$NOTIFY" "작업 완료: ${DESCRIPTION}" "$RESULT_SUMMARY" "$COLOR" "$DISCORD_AGENT"
 else
   # 시작
   PROMPT_PREVIEW=$(echo "$HOOK_INPUT" | jq -r '.tool_input.prompt // ""' | head -c 200)
-  bash "$NOTIFY" "작업 시작: ${DESCRIPTION}" "$PROMPT_PREVIEW" "info" "$DISCORD_AGENT" &
+  bash "$NOTIFY" "작업 시작: ${DESCRIPTION}" "$PROMPT_PREVIEW" "info" "$DISCORD_AGENT"
 fi
 
 exit 0

--- a/.claude/hooks/post-dev/auto-commit.sh
+++ b/.claude/hooks/post-dev/auto-commit.sh
@@ -122,7 +122,7 @@ if [ $? -eq 0 ]; then
   echo "✅ 자동 커밋 완료 (${FILE_COUNT}개 파일)"
   NOTIFY="$(cd "$(dirname "$0")" && pwd)/../notify-discord.sh"
   NOTIFY_BODY=$(printf "%s\n(%s개 파일)" "$COMMIT_MSG" "$FILE_COUNT")
-  bash "$NOTIFY" "📝 자동 커밋" "$NOTIFY_BODY" "info" 2>/dev/null &
+  bash "$NOTIFY" "📝 자동 커밋" "$NOTIFY_BODY" "info" 2>/dev/null
 else
   echo "⚠️ 자동 커밋 실패"
 fi


### PR DESCRIPTION
## 개요
Discord 알림이 시간 순서대로 도착하지 않는 문제 수정

## 변경 사항
- agent-discord.sh: `bash "$NOTIFY" ... &` → `bash "$NOTIFY" ...` (백그라운드 제거, 동기 전송)
- auto-commit.sh: 동일하게 백그라운드 제거
- orchestrator.md: Gate 스크립트가 자체 알림을 보내므로 orchestrator 중복 알림 제거
- Discord 알림 순서 규칙 추가: 동기 전송 필수, Phase 완료 후에만 다음 알림

## 원인
1. `&` 백그라운드 실행으로 알림 전송 순서 미보장
2. Gate 스크립트 알림 + orchestrator 직접 알림 이중 발송으로 순서 꼬임
3. PostToolUse 훅의 비동기 타이밍으로 이전 Phase 알림이 늦게 도착

## 스크린샷
설정 파일 변경만이므로 해당 없음

## Gate 충족 여부
| Gate | 검증 항목 | 상태 |
|------|----------|------|
| GATE1 | gateResults.gate1 | ✅ pass (설정 변경) |
| GATE2 | gateResults.gate2 | ✅ pass (설정 변경) |
| GATE3 | gateResults.gate3 | ✅ pass (설정 변경) |
| FIGMA_VERIFY | figmaVerified | ✅ 완료 (UI 변경 없음) |
| PR_REVIEW | prReviewCompleted | ⏳ 대기 |

## 테스트
- [x] 알림 전송 로직 검토 완료

## 관련 이슈
Discord 알림 순서 꼬임 문제